### PR TITLE
fix(setup): 팀원 배포를 위한 setup_dev_env.sh 견고화

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 깨끗한 Ubuntu 22.04.5 LTS에서 다음 세 줄이면 끝납니다.
 
 ```bash
-git clone <repo-url> ~/Documents/interceptor_drone
+git clone https://github.com/2026-KAU-Capstone-Design/interceptor_drone.git ~/Documents/interceptor_drone
 cd ~/Documents/interceptor_drone
 bash scripts/setup_dev_env.sh
 ```

--- a/docs/px4_params.md
+++ b/docs/px4_params.md
@@ -1,0 +1,79 @@
+# PX4 Parameters — 우리 프로젝트가 변경하는 파라미터
+
+PX4는 수백 개의 파라미터로 동작이 제어됩니다. 이 문서는 **우리 프로젝트가
+기본값과 다르게 설정하는 파라미터**만 정리합니다. 변경 이유와 실기체 단계로
+넘어갈 때 어떻게 되돌릴지를 함께 기록해서, 발표/보고서 자료로도 활용합니다.
+
+---
+
+## 시뮬레이션 단계 (현재)
+
+### `NAV_DLL_ACT = 0` — Data Link Loss Action 비활성화
+
+| 항목 | 값 |
+|---|---|
+| 기본값 | 사용 환경에 따라 다름 (PX4 v1.16 SITL 기본은 시동 차단으로 동작) |
+| 우리 값 | **0** (No Action) |
+| 적용 위치 | `~/dev/PX4-Autopilot/ROMFS/px4fmu_common/init.d-posix/airframes/4001_gz_x500` (setup 스크립트가 자동 패치) |
+
+**왜 변경했나:**
+- PX4의 사전 점검(pre-arm check) 중 "Ground Control Station(GCS) 연결 필요"
+  항목이 v1.16 SITL에서 기본 활성화되어 있어, QGroundControl을 띄우지 않으면
+  `commander takeoff` 가 `Preflight Fail: No connection to the ground control station`
+  으로 막힙니다.
+- 시뮬레이션 단계에서는 매번 GCS를 띄우는 것이 번거롭고, 어차피 지상 실험이라
+  안전 위험도 없습니다.
+- `NAV_DLL_ACT = 0` 으로 설정하면 PX4 commander의 점검 로직이 GCS를
+  시동의 필수 조건으로 간주하지 않게 됩니다.
+  (코드: `src/modules/commander/HealthAndArmingChecks/checks/rcAndDataLinkCheck.cpp`)
+
+**`NAV_DLL_ACT` 값의 의미:**
+
+| 값 | 동작 |
+|---|---|
+| 0 | No Action — 데이터 링크 손실 무시 (시뮬용) |
+| 1 | Hold — 그 자리에 정지 |
+| 2 | Return — 자동 귀환 (RTL) |
+| 3 | Land — 즉시 착륙 |
+| 5 | Terminate — 비행 종료 (프로펠러 정지) |
+
+---
+
+## 실기체 단계 (Phase 6에서 변경 예정)
+
+실기체로 옮길 때는 위 시뮬용 패치를 **반드시 되돌리거나 안전한 값으로
+변경**해야 합니다. 추천 매트릭스:
+
+| 환경 | `NAV_DLL_ACT` | 이유 |
+|---|---|---|
+| 실내 테스트 (텔레메트리 RC만) | 1 (Hold) | 통신 끊김 시 그 자리에 머묾 |
+| 실외 비행 + QGroundControl | 2 (Return) | 통신 끊김 시 자동 귀환 |
+| 페일세이프 우선 | 3 (Land) | 통신 끊김 시 가장 가까운 안전 지점에 착륙 |
+
+**되돌리는 방법:**
+1. `~/dev/PX4-Autopilot/ROMFS/px4fmu_common/init.d-posix/airframes/4001_gz_x500`
+   파일에서 `# >>> interceptor_drone params >>>` ~ `# <<< interceptor_drone params <<<`
+   블록을 삭제하거나 `NAV_DLL_ACT` 값을 변경합니다.
+2. 실기체용 별도 airframe 파일을 사용하는 경우 그 파일에 직접 설정합니다.
+3. QGroundControl에서 파라미터 탭으로 직접 수정 후 `param save` (영구 저장).
+
+---
+
+## 향후 추가 예정 (Phase별)
+
+다음은 작업이 진전되면 이 문서에 추가될 항목들입니다:
+
+| 파라미터 | 단계 | 용도 |
+|---|---|---|
+| `MPC_XY_VEL_MAX` | Phase 2 | 수평 최대 속도 (요격 기동 튜닝) |
+| `MPC_Z_VEL_MAX_UP` | Phase 2 | 상승 최대 속도 |
+| `COM_RCL_EXCEPT` | Phase 4 | RC 손실 예외 모드 (Offboard에서 RC 없이 작동) |
+| `EKF2_*` | Phase 5 | 실기체 EKF 튜닝 (HW팀에서 받은 IMU 스펙 반영) |
+
+---
+
+## 변경 이력
+
+| 날짜 | 변경 | 이유 |
+|---|---|---|
+| 2026-04-08 | `NAV_DLL_ACT = 0` 추가 (X500 airframe) | SITL에서 GCS 없이 시동 가능하도록 |

--- a/scripts/setup_dev_env.sh
+++ b/scripts/setup_dev_env.sh
@@ -6,10 +6,11 @@
 #   - ROS2 Humble Hawksbill (desktop + dev tools)
 #   - Gazebo Harmonic (LTS, osrfoundation 저장소)
 #   - ros-humble-ros-gzharmonic (ROS↔Gazebo 브리지)
-#   - PX4-Autopilot v1.16.1 + 의존성
+#   - PX4-Autopilot v1.16.1 + 의존성 + SITL airframe 패치 (NAV_DLL_ACT=0)
 #   - Micro XRCE-DDS Agent v2.4.3 (PX4↔ROS2 브리지)
-#   - ROS2 워크스페이스 빌드 (px4_msgs release/1.16 포함)
 #   - ~/.bashrc 환경변수 설정
+#   - ROS2 워크스페이스 빌드 (px4_msgs release/1.16 포함, 재시도 로직 포함)
+#   - verify_env.sh 자동 실행으로 결과 출력
 #
 # 멱등(idempotent): 두 번 이상 실행해도 안전.
 #
@@ -31,7 +32,7 @@ log()   { echo -e "${BLU}[INFO]${NC} $*"; }
 ok()    { echo -e "${GRN}[ OK ]${NC} $*"; }
 warn()  { echo -e "${YLW}[WARN]${NC} $*"; }
 err()   { echo -e "${RED}[FAIL]${NC} $*" >&2; }
-stage() { echo -e "\n${BLU}========== $* ==========${NC}"; }
+stage() { CURRENT_STAGE="$*"; echo -e "\n${BLU}========== $* ==========${NC}"; }
 
 # ---------- 핀(pin) 버전 — 변경은 PR로만 ----------
 ROS_DISTRO="humble"
@@ -44,6 +45,27 @@ DEV_DIR="${HOME}/dev"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 WS_DIR="${REPO_ROOT}/ros2_ws"
+
+# ---------- 에러 트랩 ----------
+CURRENT_STAGE="(초기화)"
+on_error() {
+    local exit_code=$?
+    local line_no=$1
+    err ""
+    err "============================================================"
+    err " 스크립트 실패"
+    err "============================================================"
+    err " 실패 단계 : ${CURRENT_STAGE}"
+    err " 라인 번호 : ${line_no}"
+    err " 종료 코드 : ${exit_code}"
+    err ""
+    err " 디버깅:"
+    err "   - 위 출력의 마지막 줄에서 에러 메시지를 확인하세요"
+    err "   - 인터넷 연결과 디스크 여유 공간을 확인하세요"
+    err "   - 같은 스크립트를 다시 실행하면 멱등하게 이어서 진행됩니다"
+    err "============================================================"
+}
+trap 'on_error $LINENO' ERR
 
 # =============================================================================
 # 사전 점검
@@ -70,8 +92,12 @@ ok "네트워크 확인"
 AVAIL_GB=$(df -BG "$HOME" | awk 'NR==2 {gsub("G",""); print $4}')
 if [ "${AVAIL_GB}" -lt 30 ]; then
     warn "홈 디렉터리 여유 공간이 ${AVAIL_GB}GB 입니다. 30GB 이상 권장."
-    read -rp "그래도 계속하시겠습니까? [y/N] " ans
-    [[ "${ans}" =~ ^[Yy]$ ]] || exit 1
+    if [ -t 0 ]; then
+        read -rp "그래도 계속하시겠습니까? [y/N] " ans
+        [[ "${ans}" =~ ^[Yy]$ ]] || exit 1
+    else
+        warn "비대화형 실행이므로 그대로 진행합니다."
+    fi
 fi
 ok "디스크 여유 공간 ${AVAIL_GB}GB"
 
@@ -162,7 +188,7 @@ else
 fi
 
 # =============================================================================
-# 4/7 PX4-Autopilot
+# 4/7 PX4-Autopilot + airframe 패치
 # =============================================================================
 stage "4/7 PX4-Autopilot ${PX4_VERSION}"
 
@@ -185,6 +211,33 @@ fi
 # PX4 의존성 설치 (Gazebo는 우리가 직접 osrfoundation에서 설치했으므로 --no-sim-tools)
 log "PX4 의존성 설치 중 (NuttX 툴체인 포함, 시간이 걸립니다)..."
 bash ./Tools/setup/ubuntu.sh --no-sim-tools
+
+# X500 SITL airframe 패치 — NAV_DLL_ACT=0 (시뮬에서 GCS 없이 시동 가능)
+PX4_AIRFRAME_FILE="${DEV_DIR}/PX4-Autopilot/ROMFS/px4fmu_common/init.d-posix/airframes/4001_gz_x500"
+PX4_PARAM_MARK="# >>> interceptor_drone params >>>"
+PX4_PARAM_END="# <<< interceptor_drone params <<<"
+
+if [ ! -f "${PX4_AIRFRAME_FILE}" ]; then
+    err "PX4 X500 airframe 파일이 없습니다: ${PX4_AIRFRAME_FILE}"
+    err "PX4 버전이 ${PX4_VERSION}이 맞는지 확인하세요."
+    exit 1
+fi
+
+if ! grep -qF "${PX4_PARAM_MARK}" "${PX4_AIRFRAME_FILE}"; then
+    cat >> "${PX4_AIRFRAME_FILE}" <<EOF
+
+${PX4_PARAM_MARK}
+# 시뮬레이션 환경에서 GCS(QGroundControl) 연결 없이 시동 가능하게 함.
+# 실기체로 옮길 때는 NAV_DLL_ACT를 1(Hold) 또는 2(Return)로 변경 권장.
+# 자세한 설명: docs/px4_params.md
+param set-default NAV_DLL_ACT 0
+${PX4_PARAM_END}
+EOF
+    ok "X500 airframe에 NAV_DLL_ACT=0 추가됨"
+else
+    ok "X500 airframe 패치 이미 적용됨 — 건너뜀"
+fi
+
 ok "PX4 ${PX4_VERSION} 준비 완료"
 
 # =============================================================================
@@ -210,34 +263,14 @@ else
 fi
 
 # =============================================================================
-# 6/7 ROS2 워크스페이스
+# 6/7 ~/.bashrc 환경변수 (워크스페이스 빌드 *전*에 설정)
 # =============================================================================
-stage "6/7 ROS2 워크스페이스 빌드"
-
-mkdir -p "${WS_DIR}/src"
-cd "${WS_DIR}"
-
-# vcstool로 외부 저장소 import (px4_msgs 등)
-if [ -f "${REPO_ROOT}/repos/dev.repos" ]; then
-    log "외부 저장소 동기화 (vcstool)..."
-    vcs import src < "${REPO_ROOT}/repos/dev.repos" || true
-    vcs pull src 2>/dev/null || true
-fi
-
-# ROS2 환경 source 후 종속성 설치
-# shellcheck disable=SC1091
-source "/opt/ros/${ROS_DISTRO}/setup.bash"
-rosdep install --from-paths src --ignore-src -r -y || \
-    warn "rosdep 일부 실패 — 다음 빌드에서 확인 필요"
-
-log "colcon build 중..."
-colcon build --symlink-install
-ok "워크스페이스 빌드 완료"
-
+# bashrc는 colcon build 결과와 무관하게 항상 설정한다.
+# 이전 버전에서는 stage 7로 마지막에 두어서, colcon build가 일시적으로 실패하면
+# bashrc까지 누락되는 사고가 있었음. 이제는 build 전에 설정하여 build가 실패해도
+# 사용자는 환경변수와 ROS2 source가 잡힌 셸을 가질 수 있다.
 # =============================================================================
-# 7/7 ~/.bashrc 환경변수
-# =============================================================================
-stage "7/7 ~/.bashrc 설정"
+stage "6/7 ~/.bashrc 설정"
 
 BASHRC_MARK="# >>> interceptor_drone env >>>"
 BASHRC_END="# <<< interceptor_drone env <<<"
@@ -259,18 +292,95 @@ else
 fi
 
 # =============================================================================
-# 완료
+# 7/7 ROS2 워크스페이스 빌드 (재시도 로직 포함)
 # =============================================================================
-stage "✔ 설치 완료"
+stage "7/7 ROS2 워크스페이스 빌드"
+
+mkdir -p "${WS_DIR}/src"
+cd "${WS_DIR}"
+
+# vcstool로 외부 저장소 import (px4_msgs 등) — 재시도 2회
+if [ -f "${REPO_ROOT}/repos/dev.repos" ]; then
+    log "외부 저장소 동기화 (vcstool)..."
+    VCS_TRIES=0
+    VCS_MAX=2
+    while [ "${VCS_TRIES}" -lt "${VCS_MAX}" ]; do
+        VCS_TRIES=$((VCS_TRIES + 1))
+        if vcs import src < "${REPO_ROOT}/repos/dev.repos" 2>/dev/null; then
+            break
+        fi
+        warn "vcs import 시도 ${VCS_TRIES}/${VCS_MAX} 실패, 재시도..."
+        sleep 5
+    done
+    vcs pull src 2>/dev/null || true
+fi
+
+# ROS2 환경 source 후 종속성 설치
+# shellcheck disable=SC1091
+source "/opt/ros/${ROS_DISTRO}/setup.bash"
+rosdep install --from-paths src --ignore-src -r -y 2>/dev/null || \
+    warn "rosdep 일부 실패 — 다음 빌드에서 확인 필요"
+
+# colcon build — 일시적 실패에 대비해 최대 3회 재시도
+COLCON_MAX_TRIES=3
+COLCON_TRY=0
+COLCON_OK=0
+while [ "${COLCON_TRY}" -lt "${COLCON_MAX_TRIES}" ]; do
+    COLCON_TRY=$((COLCON_TRY + 1))
+    log "colcon build 시도 ${COLCON_TRY}/${COLCON_MAX_TRIES}..."
+    if colcon build --symlink-install; then
+        COLCON_OK=1
+        ok "colcon build 성공"
+        break
+    fi
+    warn "colcon build 시도 ${COLCON_TRY} 실패"
+    if [ "${COLCON_TRY}" -lt "${COLCON_MAX_TRIES}" ]; then
+        log "10초 후 재시도..."
+        sleep 10
+    fi
+done
+
+if [ "${COLCON_OK}" -ne 1 ]; then
+    err ""
+    err "============================================================"
+    err " colcon build가 ${COLCON_MAX_TRIES}회 모두 실패했습니다."
+    err "============================================================"
+    err " 환경변수와 모든 의존성은 정상 설치되었습니다."
+    err " ~/.bashrc도 이미 업데이트되어 있습니다."
+    err ""
+    err " 수동으로 다시 시도하려면:"
+    err "   cd ${WS_DIR}"
+    err "   source /opt/ros/${ROS_DISTRO}/setup.bash"
+    err "   colcon build --symlink-install"
+    err ""
+    err " 새 터미널을 열고 'bash scripts/verify_env.sh'로 환경 상태를 확인하세요."
+    err "============================================================"
+    exit 1
+fi
+
+# =============================================================================
+# 완료 — verify_env.sh 자동 실행
+# =============================================================================
+stage "✔ 설치 완료 — 환경 검증"
+
+if [ -x "${SCRIPT_DIR}/verify_env.sh" ]; then
+    bash "${SCRIPT_DIR}/verify_env.sh" || true
+else
+    warn "verify_env.sh를 찾을 수 없습니다 (${SCRIPT_DIR}/verify_env.sh)"
+fi
 
 cat <<EOF
 
+============================================================
+ ✔ 환경 셋업 완료
+============================================================
+
 다음 단계:
 
-1) 새 터미널을 열거나 환경 적용:
+1) 새 터미널을 열거나 현재 터미널에서 환경 적용:
        source ~/.bashrc
 
-2) 환경 검증 (팀원 3명 출력이 동일해야 함):
+2) 환경 검증 (위 출력과 동일하게 나오는지 확인):
        bash ${REPO_ROOT}/scripts/verify_env.sh
 
 3) 첫 SITL 비행 (3개 터미널):
@@ -279,12 +389,19 @@ cat <<EOF
 
        # T2 — PX4 SITL + Gazebo Harmonic
        cd \$PX4_AUTOPILOT_DIR && make px4_sitl gz_x500
+       # (첫 빌드는 5~10분 소요)
 
        # T3 — ROS2에서 토픽 확인
        ros2 topic list | grep fmu
 
+4) pxh 프롬프트가 보이면:
+       pxh> commander takeoff
+       (NAV_DLL_ACT=0가 airframe에 박혀있어 GCS 없이 바로 시동 가능)
+
 주의:
   - PX4 의존성 설치 과정에서 사용자가 dialout 그룹에 추가됩니다.
-    실제 Pixhawk USB 통신을 위해서는 한 번 로그아웃→재로그인이 필요합니다.
+    실제 Pixhawk USB 통신 단계에서는 한 번 로그아웃→재로그인이 필요합니다.
+
+============================================================
 
 EOF


### PR DESCRIPTION
기존 스크립트가 일시적인 colcon build 실패에 멈추면 bashrc까지 누락되어
사용자가 환경변수 없는 상태로 끝나는 사고가 있었음. 다음 변경으로 해결:

- bashrc 설정을 colcon build *전*으로 이동 → 빌드 실패해도 환경 잡힘
- colcon build 최대 3회 재시도 (10초 간격)
- vcs import 최대 2회 재시도
- 에러 트랩으로 실패 단계/라인을 명확히 출력
- PX4 X500 airframe 자동 패치: NAV_DLL_ACT=0 추가 → 시뮬레이션에서 GCS(QGroundControl) 없이 commander takeoff 가능
- 디스크 공간 prompt를 비대화형 환경에서 안전하게 처리
- 마지막에 verify_env.sh 자동 실행으로 결과 즉시 출력

부수 변경:
- README.md: <repo-url> 자리에 실제 GitHub URL 삽입
- docs/px4_params.md: NAV_DLL_ACT 변경 사유와 실기체 단계 복원 가이드