### PR TITLE
fix(setup): set -u 제거 — ROS2 setup.bash와의 호환성 문제 해결

### DIFF
--- a/scripts/setup_dev_env.sh
+++ b/scripts/setup_dev_env.sh
@@ -24,7 +24,12 @@
 #   - 홈 디렉터리 30GB+ 여유 공간
 # =============================================================================
 
-set -euo pipefail
+# NOTE: set -u (nounset)는 의도적으로 사용하지 않습니다.
+# ROS2의 /opt/ros/humble/setup.bash는 내부에서 AMENT_TRACE_SETUP_FILES 등의
+# 변수를 default 없이 참조하기 때문에, set -u 상태에서 source하면 즉시 종료됩니다.
+# (ERR trap도 parameter expansion error는 잡지 못함)
+# set -e와 pipefail만으로 충분히 안전하게 동작합니다.
+set -eo pipefail
 
 # ---------- 색상 출력 ----------
 RED='\033[0;31m'; GRN='\033[0;32m'; YLW='\033[1;33m'; BLU='\033[0;34m'; NC='\033[0m'


### PR DESCRIPTION
증상:
  Stage 7 의 vcstool import 직후 source /opt/ros/humble/setup.bash 에서
  "AMENT_TRACE_SETUP_FILES: 바인딩 해제한 변수" 에러로 스크립트가 조용히 종료.
  ERR trap도 발화하지 않아 colcon build와 verify_env.sh가 실행되지 않음.

원인:
  set -u (nounset) 가 활성화된 상태에서 ROS2 setup.bash를 source하면,
  setup.bash가 default 없이 참조하는 AMENT_TRACE_SETUP_FILES 등의 변수가
  parameter expansion error를 발생시켜 즉시 셸이 종료됨.
  ERR trap은 command failure만 잡고 parameter expansion error는 잡지 못함.

수정:
  set -euo pipefail → set -eo pipefail
  set -e와 pipefail만으로도 충분히 안전하게 동작.
  주석으로 의도와 배경을 명시.