### PR TITLE
feat(sim): 가벼운 sky+ground+wind 월드 추가 (simple_windy / simple_storm)

### DIFF
--- a/missions/README.md
+++ b/missions/README.md
@@ -23,26 +23,44 @@ missions/
 
 ## 실행 환경
 
-### 무풍 (baylands)
+> **권장:** `simple_windy` / `simple_storm` 사용 (Fuel 의존성 없음, 가볍고 바람 확실히 적용).
+> baylands 계열은 지형 시각화가 필요할 때만 사용.
+
+### 무풍 / 가벼운 환경 (default 또는 baylands)
 ```bash
-# 커스텀 월드를 PX4에 복사 (최초 1회)
+# 커스텀 월드는 setup_dev_env.sh가 자동 복사. 수동으로 하려면:
 cp simulation/worlds/*.sdf ~/dev/PX4-Autopilot/Tools/simulation/gz/worlds/
 
 # T1
 MicroXRCEAgent udp4 -p 8888
-# T2
-cd $PX4_AUTOPILOT_DIR && PX4_GZ_WORLD=baylands make px4_sitl gz_x500
+# T2 — 가장 가벼운 무풍
+cd $PX4_AUTOPILOT_DIR && PX4_GZ_WORLD=default make px4_sitl gz_x500
 # T3
 ros2 run interceptor_control offboard_hover
 ```
 
-### 보통풍 (baylands_windy, ~5.4m/s)
+### 보통풍 (simple_windy, ~5.4m/s) ★ 권장
 ```bash
-# T2만 변경
-cd $PX4_AUTOPILOT_DIR && PX4_GZ_WORLD=baylands_windy make px4_sitl gz_x500
+# T2만 변경 — Fuel 다운로드 없이 빠르게 로드
+cd $PX4_AUTOPILOT_DIR && PX4_GZ_WORLD=simple_windy make px4_sitl gz_x500
 ```
 
-### 강풍 (baylands_storm, ~11.7m/s)
+### 강풍 (simple_storm, ~11.7m/s) ★ 권장
+```bash
+# T2만 변경 — 안전 모니터(WIND CRITICAL → RTL) 검증용
+cd $PX4_AUTOPILOT_DIR && PX4_GZ_WORLD=simple_storm make px4_sitl gz_x500
+```
+
+### baylands 변형 (지형 시각화 필요시)
+
+baylands 계열은 첫 실행 시 Gazebo Fuel에서 공원/해안수 모델을
+다운로드하므로 인터넷 필수이며 로딩이 느립니다.
+
+```bash
+# 보통풍 baylands
+cd $PX4_AUTOPILOT_DIR && PX4_GZ_WORLD=baylands_windy make px4_sitl gz_x500
+
+# 강풍 baylands
 ```bash
 # T2만 변경
 cd $PX4_AUTOPILOT_DIR && PX4_GZ_WORLD=baylands_storm make px4_sitl gz_x500

--- a/simulation/worlds/simple_storm.sdf
+++ b/simulation/worlds/simple_storm.sdf
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  simple_storm.sdf — 가벼운 하늘+지면 월드 + 강풍 (~11.7 m/s)
+
+  특징:
+    - simple_windy.sdf 와 동일하게 Fuel 의존성 없음, 가벼움
+    - <wind> 10 6 0 m/s = 합산 ~11.7 m/s (강풍 범위 8~15 m/s)
+    - 자세 복원 2초 이내 + 자동 RTL 안전장치 검증용
+
+  사용:
+    PX4_GZ_WORLD=simple_storm make px4_sitl gz_x500
+-->
+<sdf version="1.9">
+  <world name="simple_storm">
+    <physics type="ode">
+      <max_step_size>0.004</max_step_size>
+      <real_time_factor>1.0</real_time_factor>
+      <real_time_update_rate>250</real_time_update_rate>
+    </physics>
+    <gravity>0 0 -9.8</gravity>
+    <magnetic_field>6e-06 2.3e-05 -4.2e-05</magnetic_field>
+    <atmosphere type="adiabatic"/>
+
+    <scene>
+      <ambient>0.5 0.5 0.5 1</ambient>
+      <background>0.4 0.5 0.6 1</background>
+      <grid>false</grid>
+      <sky>
+        <clouds>
+          <speed>10</speed>
+        </clouds>
+      </sky>
+      <shadows>true</shadows>
+    </scene>
+
+    <light name="sun" type="directional">
+      <pose>0 0 500 0 -0 0</pose>
+      <cast_shadows>true</cast_shadows>
+      <intensity>0.8</intensity>
+      <direction>0.001 0.625 -0.78</direction>
+      <diffuse>0.85 0.85 0.85 1</diffuse>
+      <specular>0.2 0.2 0.2 1</specular>
+      <attenuation>
+        <range>2000</range>
+        <linear>0</linear>
+        <constant>1</constant>
+        <quadratic>0</quadratic>
+      </attenuation>
+    </light>
+
+    <model name="ground_plane">
+      <static>true</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>500 500</size>
+            </plane>
+          </geometry>
+          <surface>
+            <friction>
+              <ode/>
+            </friction>
+            <bounce/>
+            <contact/>
+          </surface>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>500 500</size>
+            </plane>
+          </geometry>
+          <material>
+            <ambient>0.3 0.4 0.3 1</ambient>
+            <diffuse>0.3 0.5 0.3 1</diffuse>
+            <specular>0.1 0.1 0.1 1</specular>
+          </material>
+        </visual>
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>1</ixx><ixy>0</ixy><ixz>0</ixz>
+            <iyy>1</iyy><iyz>0</iyz><izz>1</izz>
+          </inertia>
+        </inertial>
+        <enable_wind>true</enable_wind>
+      </link>
+    </model>
+
+    <!-- 강풍 ~11.7 m/s (강풍 범위 8~15 m/s 검증용) -->
+    <wind>
+      <linear_velocity>10 6 0</linear_velocity>
+    </wind>
+
+    <spherical_coordinates>
+      <surface_model>EARTH_WGS84</surface_model>
+      <world_frame_orientation>ENU</world_frame_orientation>
+      <latitude_deg>37.5665</latitude_deg>
+      <longitude_deg>126.9780</longitude_deg>
+      <elevation>30</elevation>
+    </spherical_coordinates>
+  </world>
+</sdf>

--- a/simulation/worlds/simple_windy.sdf
+++ b/simulation/worlds/simple_windy.sdf
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  simple_windy.sdf — 가벼운 하늘+지면 월드 + 바람 (보통풍 ~5.4 m/s)
+
+  특징:
+    - Fuel(클라우드) 모델 의존성 없음 → 인터넷 없어도 즉시 로드
+    - baylands보다 가볍고 빠름 (PX4 default.sdf 기반)
+    - 절차적 sky(파란 하늘 + 구름) + 평면 지면
+    - <wind> 5 2 0 m/s + ground_plane <enable_wind>true</enable_wind>
+    - X500 base_link에 <enable_wind>true</enable_wind> 패치 필요
+      (setup_dev_env.sh가 자동 적용)
+
+  사용:
+    PX4_GZ_WORLD=simple_windy make px4_sitl gz_x500
+-->
+<sdf version="1.9">
+  <world name="simple_windy">
+    <physics type="ode">
+      <max_step_size>0.004</max_step_size>
+      <real_time_factor>1.0</real_time_factor>
+      <real_time_update_rate>250</real_time_update_rate>
+    </physics>
+    <gravity>0 0 -9.8</gravity>
+    <magnetic_field>6e-06 2.3e-05 -4.2e-05</magnetic_field>
+    <atmosphere type="adiabatic"/>
+
+    <scene>
+      <ambient>0.6 0.6 0.6 1</ambient>
+      <background>0.5 0.7 0.9 1</background>
+      <grid>false</grid>
+      <sky>
+        <clouds>
+          <speed>4</speed>
+        </clouds>
+      </sky>
+      <shadows>true</shadows>
+    </scene>
+
+    <light name="sun" type="directional">
+      <pose>0 0 500 0 -0 0</pose>
+      <cast_shadows>true</cast_shadows>
+      <intensity>1</intensity>
+      <direction>0.001 0.625 -0.78</direction>
+      <diffuse>0.904 0.904 0.904 1</diffuse>
+      <specular>0.271 0.271 0.271 1</specular>
+      <attenuation>
+        <range>2000</range>
+        <linear>0</linear>
+        <constant>1</constant>
+        <quadratic>0</quadratic>
+      </attenuation>
+    </light>
+
+    <model name="ground_plane">
+      <static>true</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>500 500</size>
+            </plane>
+          </geometry>
+          <surface>
+            <friction>
+              <ode/>
+            </friction>
+            <bounce/>
+            <contact/>
+          </surface>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>500 500</size>
+            </plane>
+          </geometry>
+          <material>
+            <ambient>0.4 0.5 0.3 1</ambient>
+            <diffuse>0.4 0.6 0.3 1</diffuse>
+            <specular>0.1 0.1 0.1 1</specular>
+          </material>
+        </visual>
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>1</ixx><ixy>0</ixy><ixz>0</ixz>
+            <iyy>1</iyy><iyz>0</iyz><izz>1</izz>
+          </inertia>
+        </inertial>
+        <enable_wind>true</enable_wind>
+      </link>
+    </model>
+
+    <!-- 보통풍 ~5.4 m/s (정상 운용 범위 0~8 m/s 내) -->
+    <wind>
+      <linear_velocity>5 2 0</linear_velocity>
+    </wind>
+
+    <spherical_coordinates>
+      <surface_model>EARTH_WGS84</surface_model>
+      <world_frame_orientation>ENU</world_frame_orientation>
+      <latitude_deg>37.5665</latitude_deg>
+      <longitude_deg>126.9780</longitude_deg>
+      <elevation>30</elevation>
+    </spherical_coordinates>
+  </world>
+</sdf>


### PR DESCRIPTION
baylands_windy 에서 바람이 적용되지 않거나 Fuel 모델 다운로드로 로딩이
오래 걸리는 문제의 대안으로, Fuel 의존성 없는 가벼운 커스텀 월드 추가.

신규 월드:
  - simple_windy.sdf : 절차적 sky + 평면 ground + wind 5,2,0 (~5.4 m/s)
  - simple_storm.sdf : 동일 구조 + wind 10,6,0 (~11.7 m/s)

특징:
  - Gazebo Fuel(클라우드) 의존성 없음 → 인터넷 없어도 즉시 로드
  - default.sdf 기반 + <sky> 추가 + ground_plane 에 <enable_wind>true</enable_wind>
  - 100줄 미만, baylands 보다 훨씬 가벼움
  - X500 base_link 의 <enable_wind> 패치(이전 PR)와 함께 동작

문서:
  - missions/README.md: simple_windy/simple_storm 권장 사용법으로 업데이트, baylands 계열은 지형 시각화가 필요할 때만 사용하도록 명시

setup_dev_env.sh 가 simulation/worlds/*.sdf 를 PX4 worlds 폴더로 자동 복사하므로 팀원은 git pull + 스크립트 재실행만으로 새 월드 사용 가능.