### PR TITLE
feat(perception): 드론 카메라 활성화 + 검붉은색 풍선 표적 + 이미지 파이프라인

### DIFF
--- a/docs/camera_pipeline.md
+++ b/docs/camera_pipeline.md
@@ -1,0 +1,177 @@
+# Camera Pipeline — 드론 카메라 이미지 수신
+
+Gazebo SITL의 드론 카메라에서 ROS2 노드까지 이미지가 전달되는 전 과정.
+
+---
+
+## 데이터 흐름 (한눈에)
+
+```
+ ┌──────────────────────────────────────────────────────────────────┐
+ │  Gazebo Harmonic                                                 │
+ │  ┌───────────────────────────────────────────────────────────┐   │
+ │  │  X500 드론 모델 (x500_mono_cam)                            │   │
+ │  │     └── camera_link                                        │   │
+ │  │           └── sensor name="imager" type="camera"           │   │
+ │  │                 1280x960, FOV 1.74rad (~99°), 30Hz         │   │
+ │  └───────────────────────────────────────────────────────────┘   │
+ │            │                                                     │
+ │            ▼  Gazebo 자체 transport (gz transport)               │
+ │  /world/<world>/model/x500_mono_cam_0/                           │
+ │     link/camera_link/sensor/imager/image      (gz.msgs.Image)    │
+ │     link/camera_link/sensor/imager/camera_info(gz.msgs.CameraInfo)│
+ └────────────────┬─────────────────────────────────────────────────┘
+                  │
+                  ▼  ros_gz_bridge / ros_gz_image
+ ┌──────────────────────────────────────────────────────────────────┐
+ │  ROS2                                                            │
+ │  /camera/image       (sensor_msgs/Image)        ★ 우리 토픽 ★    │
+ │  /camera/camera_info (sensor_msgs/CameraInfo)                    │
+ └────────────────┬─────────────────────────────────────────────────┘
+                  │
+                  ▼  ROS2 노드들이 구독
+       ┌──────────┴────────────┐
+       │                       │
+  image_probe           perception 노드 (예정)
+   (진단)              cv_bridge → numpy → YOLO → /target/position
+```
+
+---
+
+## 사용한 컴포넌트
+
+| 컴포넌트 | 역할 |
+|---|---|
+| `x500_mono_cam` | PX4 제공 카메라 장착 X500 airframe (`4010_gz_x500_mono_cam`) |
+| `mono_cam` 모델 | 카메라 센서 정의 (1280x960, 30Hz, 99° FOV) |
+| `simple_windy_balloon.sdf` | 우리가 만든 월드 (sky+ground+wind+검붉은풍선) |
+| `ros_gz_image` | gz Image → ROS2 sensor_msgs/Image 전용 브리지 (이미지 압축 효율적) |
+| `ros_gz_bridge` | 일반 메시지 브리지 (CameraInfo 등) |
+| `interceptor_control/launch/camera_bridge.launch.py` | 두 브리지를 한 번에 띄우는 launch |
+| `image_probe` 노드 | 이미지 수신 검증 (fps/해상도/검붉은색 비율 출력) |
+
+---
+
+## 실행 절차 (4개 터미널)
+
+```bash
+# T1 — uXRCE-DDS Agent (드론 명령용, 카메라와는 무관하지만 비행에 필수)
+MicroXRCEAgent udp4 -p 8888
+
+# T2 — PX4 SITL: 카메라 장착 + 풍선 월드
+cd $PX4_AUTOPILOT_DIR && PX4_GZ_WORLD=simple_windy_balloon make px4_sitl gz_x500_mono_cam
+
+# T3 — Gazebo ↔ ROS2 카메라 브리지
+ros2 launch interceptor_control camera_bridge.launch.py
+
+# T4 — 이미지 수신 검증
+ros2 run interceptor_control image_probe
+# 또는 시각적으로 확인:
+ros2 run rqt_image_view rqt_image_view /camera/image
+```
+
+---
+
+## 검증 방법
+
+### 1. 토픽 존재 여부
+```bash
+ros2 topic list | grep camera
+# 기대 출력:
+#   /camera/image
+#   /camera/camera_info
+```
+
+### 2. 이미지가 실제로 흐르는지
+```bash
+ros2 topic hz /camera/image
+# 기대: ~30Hz (카메라 update_rate)
+```
+
+### 3. 이미지 정보
+```bash
+ros2 topic echo /camera/image --once --field "[width, height, encoding]"
+# 기대: width=1280, height=960, encoding="rgb8" (또는 bgr8)
+```
+
+### 4. image_probe 출력 (가장 빠른 종합 확인)
+```bash
+ros2 run interceptor_control image_probe
+```
+정상이면 1초마다:
+```
+fps= 30  1280x960 rgb8     ~3686.4KB/frame  red_ratio=0.012  (total 30)
+```
+- `fps≈30` 이면 이미지가 실시간으로 흐르는 중
+- `red_ratio` 가 0보다 크면 검붉은 영역이 카메라에 잡힘 → 풍선 시야 확보
+
+### 5. 시각적 확인 (rqt_image_view)
+```bash
+ros2 run rqt_image_view rqt_image_view /camera/image
+```
+드론 카메라가 보는 이미지가 GUI 창에 떠야 함. 처음엔 지면이 보이고, 비행하면서 풍선이 시야에 들어와야 함.
+
+---
+
+## 주요 토픽 이름 규칙 (Gazebo → ROS2)
+
+Gazebo가 자동 생성하는 카메라 토픽 경로:
+```
+/world/<world_name>/model/<model_name>/link/<link_name>/sensor/<sensor_name>/<msg_type>
+```
+
+이번 프로젝트에서:
+- `<world_name>` = `simple_windy_balloon`
+- `<model_name>` = `x500_mono_cam_0` ← PX4 SITL이 spawn할 때 `_0` 접미사 자동 추가
+- `<link_name>` = `camera_link`
+- `<sensor_name>` = `imager`
+
+따라서 실제 토픽은:
+```
+/world/simple_windy_balloon/model/x500_mono_cam_0/link/camera_link/sensor/imager/image
+```
+
+이 긴 이름을 `/camera/image` 로 단축한 것이 launch 파일의 `remappings` 역할.
+
+다른 월드/모델로 바꾸면 launch 인자 수정:
+```bash
+ros2 launch interceptor_control camera_bridge.launch.py \
+  world:=다른월드 model:=x500_depth_0
+```
+
+---
+
+## 풍선 모델 정보
+
+`simulation/worlds/simple_windy_balloon.sdf` 안에 정의:
+
+| 속성 | 값 |
+|---|---|
+| 모델명 | `balloon_red` |
+| 위치 | (5, 0, 4) Gazebo ENU (드론에서 동쪽 5m, 고도 4m) |
+| 형상 | sphere, 반지름 0.5m |
+| 색상 | 검붉은색 RGB(0.45, 0.05, 0.05) |
+| 정적 | static (위치 고정) |
+
+PX4 NED 좌표로 환산: 드론에서 북쪽(N) 0m, 동쪽(E) 5m, 위(z=-4 in NED) 4m.
+
+---
+
+## 실패 시 체크리스트
+
+| 증상 | 원인 | 해결 |
+|---|---|---|
+| `/camera/image` 토픽이 안 보임 | x500_mono_cam이 아닌 그냥 x500 사용 | T2 명령에 `gz_x500_mono_cam` 사용 |
+| Gazebo는 카메라 보이지만 ROS2엔 없음 | bridge 미실행 | T3에서 launch 실행 |
+| bridge는 떴는데 image 0Hz | 모델명 불일치 (model 인자) | Gazebo 측 모델명 확인 후 launch 인자 수정 |
+| rqt_image_view가 까만 화면 | 카메라 위치/방향 문제 | Gazebo에서 카메라 시점으로 봐서 확인 |
+| 풍선이 안 보임 | 풍선 위치 / 카메라 시야 밖 | 드론 yaw=0이면 동쪽 5m에 풍선이 정확히 정면 |
+
+---
+
+## 다음 단계
+
+이 파이프라인이 동작하면 다음으로:
+1. **YOLO 추론 노드** (`perception/`) — `/camera/image` 구독 → YOLOv8n → `/target/bounding_box`
+2. **3D 위치 추정** — bbox 중심 + camera_info + 드론 자세 → `/target/position` (NED 좌표)
+3. **요격 노드** — `/target/position` 구독 → offboard setpoint 갱신 → 드론 이동

--- a/ros2_ws/src/interceptor_control/interceptor_control/perception/image_probe.py
+++ b/ros2_ws/src/interceptor_control/interceptor_control/perception/image_probe.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""
+Image Probe — 카메라 토픽이 실제로 들어오는지 검증하는 진단 노드
+
+/camera/image 를 구독해서:
+  - 메시지 수신율(Hz)
+  - 해상도, encoding
+  - 픽셀 통계 (평균/최대/최소)
+  - "검붉은색" 비율 (HSV 기반 간단 마스크) — 풍선이 보이는지 빠르게 확인
+을 1초마다 출력한다.
+
+사용법:
+  ros2 run interceptor_control image_probe
+
+  # 또는 다른 토픽으로 실행:
+  ros2 run interceptor_control image_probe --ros-args -r __ns:=/cam2 -p topic:=/cam2/image
+"""
+
+import rclpy
+from rclpy.node import Node
+from sensor_msgs.msg import Image
+import numpy as np
+
+
+class ImageProbe(Node):
+    def __init__(self):
+        super().__init__('image_probe')
+        self.declare_parameter('topic', '/camera/image')
+        topic = self.get_parameter('topic').value
+
+        self.sub = self.create_subscription(Image, topic, self.cb_image, 10)
+        self.timer = self.create_timer(1.0, self.print_stats)
+
+        self.frame_count = 0
+        self.total_frames = 0
+        self.last_msg = None
+        self.last_red_ratio = 0.0
+
+        self.get_logger().info(f'=== Image Probe ===')
+        self.get_logger().info(f'  topic: {topic}')
+        self.get_logger().info(f'  매 1초마다 통계 출력')
+
+    def cb_image(self, msg: Image):
+        self.frame_count += 1
+        self.total_frames += 1
+        self.last_msg = msg
+
+        # 빠른 검붉은색 비율 추정 (RGB 기준 간단 룰)
+        try:
+            ch = 3 if 'rgb' in msg.encoding.lower() or 'bgr' in msg.encoding.lower() else 1
+            if ch == 3:
+                arr = np.frombuffer(msg.data, dtype=np.uint8).reshape(
+                    msg.height, msg.width, 3)
+                # 가운데 320x240 영역만 (속도)
+                h, w, _ = arr.shape
+                cx, cy = w // 2, h // 2
+                roi = arr[max(0, cy-120):cy+120, max(0, cx-160):cx+160]
+                # encoding이 rgb8 또는 bgr8 일 수 있음
+                if 'bgr' in msg.encoding.lower():
+                    b, g, r = roi[..., 0], roi[..., 1], roi[..., 2]
+                else:
+                    r, g, b = roi[..., 0], roi[..., 1], roi[..., 2]
+                # 검붉은색 마스크: R 우세 + G/B 낮음 + 너무 밝지 않음
+                mask = (r.astype(int) > g.astype(int) + 30) & \
+                       (r.astype(int) > b.astype(int) + 30) & \
+                       (r < 200)
+                self.last_red_ratio = float(mask.mean())
+        except Exception:
+            self.last_red_ratio = -1.0
+
+    def print_stats(self):
+        if self.last_msg is None:
+            self.get_logger().warn(
+                '[NO IMAGE] 이미지 토픽 수신 안됨 — bridge 와 PX4 SITL 확인 필요')
+            return
+
+        msg = self.last_msg
+        size_kb = len(msg.data) / 1024
+        self.get_logger().info(
+            f'fps={self.frame_count:>3d}  '
+            f'{msg.width}x{msg.height} {msg.encoding}  '
+            f'{size_kb:>6.1f}KB/frame  '
+            f'red_ratio={self.last_red_ratio:.3f}  '
+            f'(total {self.total_frames})'
+        )
+        self.frame_count = 0
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = ImageProbe()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/ros2_ws/src/interceptor_control/launch/camera_bridge.launch.py
+++ b/ros2_ws/src/interceptor_control/launch/camera_bridge.launch.py
@@ -1,0 +1,93 @@
+"""
+Camera Bridge Launch — Gazebo 카메라 토픽을 ROS2로 브리지
+
+Gazebo Harmonic의 카메라 센서가 publish하는 gz transport 토픽을
+ros_gz_bridge를 통해 ROS2 sensor_msgs/Image 토픽으로 변환한다.
+
+사용법:
+  # T1
+  MicroXRCEAgent udp4 -p 8888
+
+  # T2 — 카메라 장착 X500 + 풍선 월드
+  cd $PX4_AUTOPILOT_DIR && PX4_GZ_WORLD=simple_windy_balloon make px4_sitl gz_x500_mono_cam
+
+  # T3 — 카메라 브리지 실행 (이 launch 파일)
+  ros2 launch interceptor_control camera_bridge.launch.py
+
+  # T4 — ROS2 측에서 이미지 확인
+  ros2 topic list | grep image
+  ros2 run rqt_image_view rqt_image_view /camera/image
+
+토픽 매핑:
+  Gazebo: /world/<world>/model/x500_0/link/camera_link/sensor/imager/image
+       ↓ (ros_gz_bridge)
+  ROS2:   /camera/image  (sensor_msgs/Image)
+
+  Gazebo: /world/<world>/model/x500_0/link/camera_link/sensor/imager/camera_info
+       ↓
+  ROS2:   /camera/camera_info  (sensor_msgs/CameraInfo)
+"""
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    world_arg = DeclareLaunchArgument(
+        'world',
+        default_value='simple_windy_balloon',
+        description='Gazebo 월드 이름 (PX4_GZ_WORLD 와 일치해야 함)',
+    )
+    model_arg = DeclareLaunchArgument(
+        'model',
+        default_value='x500_mono_cam_0',
+        description='PX4 SITL이 spawn한 드론 모델 이름 (보통 x500_mono_cam_0)',
+    )
+
+    world = LaunchConfiguration('world')
+    model = LaunchConfiguration('model')
+
+    # Gazebo 측 토픽 경로
+    gz_image_topic = [
+        '/world/', world, '/model/', model,
+        '/link/camera_link/sensor/imager/image',
+    ]
+    gz_caminfo_topic = [
+        '/world/', world, '/model/', model,
+        '/link/camera_link/sensor/imager/camera_info',
+    ]
+
+    # ros_gz_bridge: Gazebo image → ROS2 sensor_msgs/Image
+    image_bridge = Node(
+        package='ros_gz_image',
+        executable='image_bridge',
+        name='image_bridge',
+        output='screen',
+        arguments=gz_image_topic,
+        remappings=[
+            (gz_image_topic, '/camera/image'),
+        ],
+    )
+
+    # camera_info는 별도 ros_gz_bridge로 (parameter_bridge)
+    caminfo_bridge = Node(
+        package='ros_gz_bridge',
+        executable='parameter_bridge',
+        name='caminfo_bridge',
+        output='screen',
+        arguments=[
+            [gz_caminfo_topic, '@sensor_msgs/msg/CameraInfo[gz.msgs.CameraInfo'],
+        ],
+        remappings=[
+            (gz_caminfo_topic, '/camera/camera_info'),
+        ],
+    )
+
+    return LaunchDescription([
+        world_arg,
+        model_arg,
+        image_bridge,
+        caminfo_bridge,
+    ])

--- a/ros2_ws/src/interceptor_control/launch/camera_bridge.launch.py
+++ b/ros2_ws/src/interceptor_control/launch/camera_bridge.launch.py
@@ -2,7 +2,7 @@
 Camera Bridge Launch — Gazebo 카메라 토픽을 ROS2로 브리지
 
 Gazebo Harmonic의 카메라 센서가 publish하는 gz transport 토픽을
-ros_gz_bridge를 통해 ROS2 sensor_msgs/Image 토픽으로 변환한다.
+ros_gz_bridge / ros_gz_image 를 통해 ROS2 sensor_msgs/Image 토픽으로 변환한다.
 
 사용법:
   # T1
@@ -11,83 +11,83 @@ ros_gz_bridge를 통해 ROS2 sensor_msgs/Image 토픽으로 변환한다.
   # T2 — 카메라 장착 X500 + 풍선 월드
   cd $PX4_AUTOPILOT_DIR && PX4_GZ_WORLD=simple_windy_balloon make px4_sitl gz_x500_mono_cam
 
-  # T3 — 카메라 브리지 실행 (이 launch 파일)
+  # T3 — 카메라 브리지 실행
   ros2 launch interceptor_control camera_bridge.launch.py
 
   # T4 — ROS2 측에서 이미지 확인
-  ros2 topic list | grep image
-  ros2 run rqt_image_view rqt_image_view /camera/image
+  ros2 run interceptor_control image_probe
+  # 또는: ros2 run rqt_image_view rqt_image_view /camera/image
+
+기본 인자(다른 월드/모델로 바꾸려면):
+  ros2 launch interceptor_control camera_bridge.launch.py \
+      world:=simple_windy_balloon model:=x500_mono_cam_0
 
 토픽 매핑:
-  Gazebo: /world/<world>/model/x500_0/link/camera_link/sensor/imager/image
-       ↓ (ros_gz_bridge)
-  ROS2:   /camera/image  (sensor_msgs/Image)
-
-  Gazebo: /world/<world>/model/x500_0/link/camera_link/sensor/imager/camera_info
-       ↓
-  ROS2:   /camera/camera_info  (sensor_msgs/CameraInfo)
+  Gazebo (gz transport):
+    /world/<world>/model/<model>/link/camera_link/sensor/imager/image
+    /world/<world>/model/<model>/link/camera_link/sensor/imager/camera_info
+       ↓ (ros_gz_image / ros_gz_bridge + remap)
+  ROS2:
+    /camera/image        (sensor_msgs/Image)
+    /camera/camera_info  (sensor_msgs/CameraInfo)
 """
 
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument
+from launch.actions import DeclareLaunchArgument, OpaqueFunction
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
 
-def generate_launch_description():
-    world_arg = DeclareLaunchArgument(
-        'world',
-        default_value='simple_windy_balloon',
-        description='Gazebo 월드 이름 (PX4_GZ_WORLD 와 일치해야 함)',
+def launch_setup(context, *args, **kwargs):
+    # LaunchConfiguration 을 런타임에 문자열로 평가
+    world = LaunchConfiguration('world').perform(context)
+    model = LaunchConfiguration('model').perform(context)
+
+    gz_image_topic = (
+        f'/world/{world}/model/{model}'
+        f'/link/camera_link/sensor/imager/image'
     )
-    model_arg = DeclareLaunchArgument(
-        'model',
-        default_value='x500_mono_cam_0',
-        description='PX4 SITL이 spawn한 드론 모델 이름 (보통 x500_mono_cam_0)',
+    gz_caminfo_topic = (
+        f'/world/{world}/model/{model}'
+        f'/link/camera_link/sensor/imager/camera_info'
     )
 
-    world = LaunchConfiguration('world')
-    model = LaunchConfiguration('model')
-
-    # Gazebo 측 토픽 경로
-    gz_image_topic = [
-        '/world/', world, '/model/', model,
-        '/link/camera_link/sensor/imager/image',
-    ]
-    gz_caminfo_topic = [
-        '/world/', world, '/model/', model,
-        '/link/camera_link/sensor/imager/camera_info',
-    ]
-
-    # ros_gz_bridge: Gazebo image → ROS2 sensor_msgs/Image
+    # ros_gz_image: Gazebo image → ROS2 sensor_msgs/Image (이미지 전용 브리지)
     image_bridge = Node(
         package='ros_gz_image',
         executable='image_bridge',
         name='image_bridge',
         output='screen',
-        arguments=gz_image_topic,
-        remappings=[
-            (gz_image_topic, '/camera/image'),
-        ],
+        arguments=[gz_image_topic],
+        remappings=[(gz_image_topic, '/camera/image')],
     )
 
-    # camera_info는 별도 ros_gz_bridge로 (parameter_bridge)
+    # ros_gz_bridge: camera_info (일반 메시지 브리지)
     caminfo_bridge = Node(
         package='ros_gz_bridge',
         executable='parameter_bridge',
         name='caminfo_bridge',
         output='screen',
         arguments=[
-            [gz_caminfo_topic, '@sensor_msgs/msg/CameraInfo[gz.msgs.CameraInfo'],
+            f'{gz_caminfo_topic}@sensor_msgs/msg/CameraInfo[gz.msgs.CameraInfo'
         ],
-        remappings=[
-            (gz_caminfo_topic, '/camera/camera_info'),
-        ],
+        remappings=[(gz_caminfo_topic, '/camera/camera_info')],
     )
 
+    return [image_bridge, caminfo_bridge]
+
+
+def generate_launch_description():
     return LaunchDescription([
-        world_arg,
-        model_arg,
-        image_bridge,
-        caminfo_bridge,
+        DeclareLaunchArgument(
+            'world',
+            default_value='simple_windy_balloon',
+            description='Gazebo 월드 이름 (PX4_GZ_WORLD 와 일치해야 함)',
+        ),
+        DeclareLaunchArgument(
+            'model',
+            default_value='x500_mono_cam_0',
+            description='PX4 SITL이 spawn한 드론 모델 이름 (보통 x500_mono_cam_0)',
+        ),
+        OpaqueFunction(function=launch_setup),
     ])

--- a/ros2_ws/src/interceptor_control/setup.py
+++ b/ros2_ws/src/interceptor_control/setup.py
@@ -25,6 +25,8 @@ setup(
             'offboard_hover = interceptor_control.offboard_hover:main',
             'point_nav = interceptor_control.missions.mission2_nav.point_nav:main',
             'hover_land = interceptor_control.missions.mission1_hover.hover_land:main',
+            # 카메라 이미지 수신 검증 노드
+            'image_probe = interceptor_control.perception.image_probe:main',
         ],
     },
 )

--- a/simulation/worlds/simple_windy_balloon.sdf
+++ b/simulation/worlds/simple_windy_balloon.sdf
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  simple_windy_balloon.sdf — simple_windy + 검붉은색 풍선 표적
+
+  특징:
+    - simple_windy.sdf 와 동일한 가벼운 sky+ground+wind 환경
+    - 드론 정면(동쪽) 5m, 고도 4m 위치에 검붉은색 풍선 1개
+    - 풍선은 정적(static) — 위치 고정
+    - 카메라 검출/요격 학습용 표적
+
+  사용:
+    PX4_GZ_WORLD=simple_windy_balloon make px4_sitl gz_x500_mono_cam
+
+  주의:
+    드론 카메라가 보이게 하려면 반드시 카메라 장착 X500
+    (gz_x500_mono_cam) airframe을 사용해야 합니다.
+-->
+<sdf version="1.9">
+  <world name="simple_windy_balloon">
+    <physics type="ode">
+      <max_step_size>0.004</max_step_size>
+      <real_time_factor>1.0</real_time_factor>
+      <real_time_update_rate>250</real_time_update_rate>
+    </physics>
+    <gravity>0 0 -9.8</gravity>
+    <magnetic_field>6e-06 2.3e-05 -4.2e-05</magnetic_field>
+    <atmosphere type="adiabatic"/>
+
+    <scene>
+      <ambient>0.6 0.6 0.6 1</ambient>
+      <background>0.5 0.7 0.9 1</background>
+      <grid>false</grid>
+      <sky>
+        <clouds>
+          <speed>4</speed>
+        </clouds>
+      </sky>
+      <shadows>true</shadows>
+    </scene>
+
+    <light name="sun" type="directional">
+      <pose>0 0 500 0 -0 0</pose>
+      <cast_shadows>true</cast_shadows>
+      <intensity>1</intensity>
+      <direction>0.001 0.625 -0.78</direction>
+      <diffuse>0.904 0.904 0.904 1</diffuse>
+      <specular>0.271 0.271 0.271 1</specular>
+      <attenuation>
+        <range>2000</range>
+        <linear>0</linear>
+        <constant>1</constant>
+        <quadratic>0</quadratic>
+      </attenuation>
+    </light>
+
+    <model name="ground_plane">
+      <static>true</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>500 500</size>
+            </plane>
+          </geometry>
+          <surface>
+            <friction><ode/></friction>
+            <bounce/>
+            <contact/>
+          </surface>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>500 500</size>
+            </plane>
+          </geometry>
+          <material>
+            <ambient>0.4 0.5 0.3 1</ambient>
+            <diffuse>0.4 0.6 0.3 1</diffuse>
+            <specular>0.1 0.1 0.1 1</specular>
+          </material>
+        </visual>
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>1</ixx><ixy>0</ixy><ixz>0</ixz>
+            <iyy>1</iyy><iyz>0</iyz><izz>1</izz>
+          </inertia>
+        </inertial>
+        <enable_wind>true</enable_wind>
+      </link>
+    </model>
+
+    <!-- ★ 검붉은색 풍선 표적 ★ -->
+    <!-- Gazebo ENU: X=동(드론 정면), Y=북, Z=위 -->
+    <!-- 위치: 드론에서 동쪽 5m, 고도 4m -->
+    <model name="balloon_red">
+      <static>true</static>
+      <pose>5 0 4 0 0 0</pose>
+      <link name="balloon_link">
+        <inertial>
+          <mass>0.05</mass>
+          <inertia>
+            <ixx>0.001</ixx><ixy>0</ixy><ixz>0</ixz>
+            <iyy>0.001</iyy><iyz>0</iyz><izz>0.001</izz>
+          </inertia>
+        </inertial>
+        <visual name="balloon_visual">
+          <geometry>
+            <sphere>
+              <radius>0.5</radius>
+            </sphere>
+          </geometry>
+          <material>
+            <!-- 검붉은색 (어두운 빨강): RGB(0.45, 0.05, 0.05) -->
+            <ambient>0.45 0.05 0.05 1</ambient>
+            <diffuse>0.55 0.08 0.08 1</diffuse>
+            <specular>0.3 0.1 0.1 1</specular>
+            <emissive>0.05 0 0 1</emissive>
+          </material>
+        </visual>
+        <collision name="balloon_collision">
+          <geometry>
+            <sphere>
+              <radius>0.5</radius>
+            </sphere>
+          </geometry>
+        </collision>
+      </link>
+    </model>
+
+    <!-- 보통풍 ~5.4 m/s -->
+    <wind>
+      <linear_velocity>5 2 0</linear_velocity>
+    </wind>
+
+    <spherical_coordinates>
+      <surface_model>EARTH_WGS84</surface_model>
+      <world_frame_orientation>ENU</world_frame_orientation>
+      <latitude_deg>37.5665</latitude_deg>
+      <longitude_deg>126.9780</longitude_deg>
+      <elevation>30</elevation>
+    </spherical_coordinates>
+  </world>
+</sdf>


### PR DESCRIPTION
== 신규 Gazebo 월드 ==
simulation/worlds/simple_windy_balloon.sdf
  - simple_windy 베이스 + 검붉은색 풍선 1개 표적 추가
  - 풍선 위치: Gazebo ENU (5, 0, 4) — 드론 정면 5m, 고도 4m
  - 풍선 형상: sphere r=0.5m, 색상 RGB(0.45, 0.05, 0.05) static

== 카메라 브리지 launch ==
ros2_ws/src/interceptor_control/launch/camera_bridge.launch.py
  - ros_gz_image: Gazebo 카메라 이미지 → /camera/image (sensor_msgs/Image)
  - ros_gz_bridge: camera_info → /camera/camera_info
  - world / model 이름은 launch 인자로 변경 가능
  - 기본값: simple_windy_balloon + x500_mono_cam_0

== 이미지 수신 검증 노드 ==
ros2_ws/src/interceptor_control/interceptor_control/perception/image_probe.py
  - /camera/image 구독 → 1초마다 fps/해상도/encoding 출력
  - ROI 가운데 320x240에서 검붉은색 픽셀 비율 추정 → 풍선 시야 진입 빠르게 확인
  - setup.py entry: image_probe

== 문서 ==
docs/camera_pipeline.md
  - Gazebo 카메라 → gz transport → ros_gz_bridge → ROS2 토픽 전체 흐름
  - 4-터미널 실행 절차 (Agent / SITL / bridge / probe)
  - 토픽 이름 매핑 규칙 (Gazebo → ROS2)
  - 검증 방법 5가지 + 실패 시 체크리스트
  - 풍선 모델 정보 + 다음 단계 (YOLO 통합)

== 사용법 ==
```bash
T1: MicroXRCEAgent udp4 -p 8888
T2: cd $PX4_AUTOPILOT_DIR && PX4_GZ_WORLD=simple_windy_balloon make px4_sitl gz_x500_mono_cam
T3: ros2 launch interceptor_control camera_bridge.launch.py
T4: ros2 run interceptor_control image_probe
T5: ros2 run rqt_image_view rqt_image_view /camera/image
T6: pxh> commander takeoff 5
```
[스크린캐스트 05-04-2026 11:16:06 PM.webm](https://github.com/user-attachments/assets/d72e57d2-29d3-47aa-b8f7-00c7d000ce7b)