### PR TITLE
test(perception): add Standard VTOL moving target integration setup

### DIFF
--- a/tools/move_standard_vtol_target.sh
+++ b/tools/move_standard_vtol_target.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+WORLD="${1:-simple_standard_vtol_target}"
+MODEL="${2:-target_fixed_wing}"
+
+echo "[move_target] world: ${WORLD}"
+echo "[move_target] model: ${MODEL}"
+
+t=0
+
+while true; do
+  values=$(python3 - <<PY
+import math
+
+t = ${t}
+
+# 표적 위치 궤적
+x = 9.0 + 2.0 * math.sin(t * 0.04)
+y = 1.5 * math.sin(t * 0.025)
+z = 3.5
+
+# yaw 회전
+yaw = 3.14 + 0.25 * math.sin(t * 0.03)
+
+# yaw -> quaternion
+qx = 0.0
+qy = 0.0
+qz = math.sin(yaw / 2.0)
+qw = math.cos(yaw / 2.0)
+
+print(f"{x} {y} {z} {qx} {qy} {qz} {qw}")
+PY
+)
+
+  read x y z qx qy qz qw <<< "$values"
+
+  gz service -s /world/${WORLD}/set_pose \
+    --reqtype gz.msgs.Pose \
+    --reptype gz.msgs.Boolean \
+    --timeout 1000 \
+    --req "name: '${MODEL}', position: {x: ${x}, y: ${y}, z: ${z}}, orientation: {x: ${qx}, y: ${qy}, z: ${qz}, w: ${qw}}" > /dev/null
+
+  t=$((t + 1))
+  sleep 0.05
+done

--- a/tools/run_yolo_live.sh
+++ b/tools/run_yolo_live.sh
@@ -5,7 +5,7 @@ cd ~/Documents/interceptor_drone/ros2_ws
 source install/setup.bash
 
 python3 ~/Documents/interceptor_drone/tools/yolo_live_detect.py \
-  --model /home/ljy0313/Documents/interceptor_drone/ros2_ws/runs/detect/balloon_yolov8n_v3/weights/best.pt \
+  --model /home/ljy0313/Documents/interceptor_drone/ros2_ws/src/interceptor_control/models/target_yolov8n_v9_standard_vtol_front_best.pt \
   --topic /camera/image \
   --conf 0.4 \
   --show \

--- a/tools/yolo_live_detect.py
+++ b/tools/yolo_live_detect.py
@@ -153,7 +153,7 @@ class YoloLiveDetector(Node):
 
         return red_pixels / max(total_pixels, 1)
 
-    def pass_geometry_filter(self, x1, y1, x2, y2, image_w, image_h):
+    def pass_geometry_filter(self, cls_id, x1, y1, x2, y2, image_w, image_h):
         box_w = max(1, x2 - x1)
         box_h = max(1, y2 - y1)
         area = box_w * box_h
@@ -166,8 +166,18 @@ class YoloLiveDetector(Node):
             return False, f"area too large: {area / image_area:.3f}"
 
         aspect = box_w / box_h
-        if aspect < self.min_aspect_ratio or aspect > self.max_aspect_ratio:
-            return False, f"bad aspect: {aspect:.2f}"
+
+        # class 0: balloon
+        # 풍선은 대체로 둥근 물체이므로 기존 aspect ratio 기준 사용
+        if cls_id == 0:
+            if aspect < self.min_aspect_ratio or aspect > self.max_aspect_ratio:
+                return False, f"balloon bad aspect: {aspect:.2f}"
+
+        # class 1: fixed_wing_uav
+        # 고정익은 정면에서 가로로 길고 세로로 얇게 보일 수 있으므로 더 넓게 허용
+        elif cls_id == 1:
+            if aspect < 0.08 or aspect > 20.0:
+                return False, f"fixed_wing_uav bad aspect: {aspect:.2f}"
 
         return True, "ok"
 
@@ -275,6 +285,7 @@ class YoloLiveDetector(Node):
         if boxes is not None and len(boxes) > 0:
             for box in boxes:
                 cls_id = int(box.cls[0].item())
+                class_name = self.model.names.get(cls_id, str(cls_id))
                 conf = float(box.conf[0].item())
                 x1, y1, x2, y2 = box.xyxy[0].cpu().numpy().astype(int)
 
@@ -283,27 +294,39 @@ class YoloLiveDetector(Node):
                 cx = (x1 + x2) / 2.0
                 cy = (y1 + y2) / 2.0
 
-                ok_geom, reason_geom = self.pass_geometry_filter(x1, y1, x2, y2, image_w, image_h)
+                ok_geom, reason_geom = self.pass_geometry_filter(cls_id, x1, y1, x2, y2, image_w, image_h)
                 if not ok_geom:
                     self.get_logger().debug(f"reject geometry: {reason_geom}")
                     continue
 
                 red_ratio = self.compute_red_ratio(frame, x1, y1, x2, y2)
-                if red_ratio < self.min_red_ratio:
-                    self.get_logger().info(
-                        f"reject red_ratio={red_ratio:.3f} conf={conf:.3f} bbox=({x1},{y1},{x2},{y2})"
-                    )
-                    continue
 
-                ok_jump, reason_jump = self.pass_jump_filter(cx, cy)
-                if not ok_jump:
-                    self.get_logger().info(
-                        f"reject jump: {reason_jump} conf={conf:.3f} bbox=({x1},{y1},{x2},{y2})"
-                    )
-                    continue
+                # class 0: balloon
+                # class 1: fixed_wing_uav
+                # red_ratio 필터는 빨간 풍선에만 적용한다.
+                if cls_id == 0:
+                    if red_ratio < self.min_red_ratio:
+                        self.get_logger().info(
+                            f"reject balloon red_ratio={red_ratio:.3f} conf={conf:.3f} bbox=({x1},{y1},{x2},{y2})"
+                        )
+                        continue
+
+                # Jump filter
+                # balloon은 기존처럼 적용
+                # fixed_wing_uav는 정면/측면 전환 시 bbox 중심이 크게 튈 수 있으므로 skip
+                if cls_id == 0:
+                    ok_jump, reason_jump = self.pass_jump_filter(cx, cy)
+                    if not ok_jump:
+                        self.get_logger().info(
+                            f"reject jump: {reason_jump} class={class_name} conf={conf:.3f} bbox=({x1},{y1},{x2},{y2})"
+                        )
+                        continue
+                else:
+                    ok_jump = True
 
                 candidates.append({
                     "cls_id": cls_id,
+                    "class_name": class_name,
                     "conf": conf,
                     "x1": x1,
                     "y1": y1,
@@ -401,7 +424,7 @@ class YoloLiveDetector(Node):
             2,
         )
 
-        label = f"balloon {best['conf']:.2f} {distance_m:.2f}m red {best['red_ratio']:.2f}"
+        label = f"{best['class_name']} {best['conf']:.2f} {distance_m:.2f}m red {best['red_ratio']:.2f}"
         cv2.putText(
             annotated,
             label,


### PR DESCRIPTION
## Summary

Standard VTOL 표적을 Gazebo 내에서 움직이도록 하는 테스트 스크립트를 추가했습니다.  
팀원 제어 PR의 IBVS 요격 제어와 YOLO fixed_wing_uav 인식을 함께 테스트하기 위한 통합 테스트용 변경입니다.

## 변경 내용

- `move_standard_vtol_target.sh` 추가
- `target_fixed_wing` 모델을 `/world/simple_standard_vtol_target/set_pose` 서비스로 이동
- Standard VTOL world에서 YOLO live detection 및 intercept 제어 노드 연동 테스트

## 테스트 / 검증

- [x] `simple_standard_vtol_target` world 실행 확인
- [x] `target_fixed_wing` 표적 이동 확인
- [x] YOLO live에서 `fixed_wing_uav` bbox 검출 확인
- [x] 팀원 IBVS 제어 노드와 연동하여 격추 동작 확인